### PR TITLE
Updating the incorrect output

### DIFF
--- a/src/generators.py
+++ b/src/generators.py
@@ -8,4 +8,4 @@ getsizeof(L) # 351064 bytes
 # Efficient way 🔥: Use a generator ✅
 G = (n for n in range(42_000))
 sum(G) # 881979000 bytes
-getsizeof(G) # 112 bytes
+getsizeof(G) # 200 bytes


### PR DESCRIPTION
getsizeof(G) bytes returns 200 (bytes) instead of 112.